### PR TITLE
Add support to download a single language

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,14 @@ The location of the file to be uploaded, relative to `Gruntfile.js`
 
 ### Download
 
+#### targetLanguage
+
+Type: `String`
+Default: `'all'`
+
+Target language files to download. If not specified, 'all' will be used and all available languages will be downloaded.
+
+
 #### outputDir
 
 Type: `String`

--- a/tasks/crowdin-request.js
+++ b/tasks/crowdin-request.js
@@ -22,7 +22,8 @@ module.exports = function(grunt) {
       endpointUrl: 'https://api.crowdin.com/api',
       apiKey: this.options()['api-key'],
       projectIndentifier: this.options()['project-identifier'],
-      branch: this.options()['branch']
+      branch: this.options()['branch'],
+      targetLanguage: this.data.targetLanguage || 'all'
     });
 
     var done = this.async();
@@ -250,7 +251,8 @@ module.exports = function(grunt) {
    * @returns {String}
    */
   Crowdin.prototype.download = function () {
-    var url = this.formUrl('download/all.zip') + '?key=' + this.config.apiKey;
+    var file = this.config.targetLanguage + '.zip';
+    var url = this.formUrl('download/' + file) + '?key=' + this.config.apiKey;
     if (this.config.branch) {
       url += '&branch=' + this.config.branch;
     }


### PR DESCRIPTION
Add support to download a single language instead of languages in the server.

By default, it downloads every language as it used to (targetLanguage = 'all') but it can download a single language overriding targetLanguage property